### PR TITLE
Removed unnecessary "out" from main.m

### DIFF
--- a/main.m
+++ b/main.m
@@ -1,4 +1,4 @@
-function [out] = main()
+function [] = main()
 % 
 % switch getenv('ENV')
 %     case 'IUHPC'


### PR DESCRIPTION
This suppresses following error message.

```
Output argument "out" (and maybe others) not assigned during call to "main".

MATLAB:unassignedOutputs
Error:Output argument "out" (and maybe others) not assigned during call to "main".
```